### PR TITLE
Effects

### DIFF
--- a/SignalsDotnet/SignalsDotnet.Tests/EffectTests.cs
+++ b/SignalsDotnet/SignalsDotnet.Tests/EffectTests.cs
@@ -1,0 +1,108 @@
+﻿using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
+using FluentAssertions;
+
+namespace SignalsDotnet.Tests;
+public class EffectTests
+{
+    [Fact]
+    void ShouldRunWhenAnySignalChanges()
+    {
+        var number1 = new Signal<int>();
+        var number2 = new Signal<int>();
+
+        int sum = -1;
+        var effect = new Effect(() => sum = number1.Value + number2.Value);
+        sum.Should().Be(0);
+
+        number1.Value = 1;
+        sum.Should().Be(1);
+
+        number1.Value = 2;
+        sum.Should().Be(2);
+
+        number2.Value = 2;
+        sum.Should().Be(4);
+
+        effect.Dispose();
+
+        number2.Value = 3;
+        sum.Should().Be(4);
+    }
+
+    [Fact]
+    void ShouldRunOnSpecifiedScheduler()
+    {
+        var scheduler = new TestScheduler();
+        var number1 = new Signal<int>();
+        var number2 = new Signal<int>();
+
+        int sum = -1;
+        var effect = new Effect(() => sum = number1.Value + number2.Value, scheduler);
+        sum.Should().Be(0);
+
+        number1.Value = 1;
+        sum.Should().Be(0);
+
+        number1.Value = 2;
+        sum.Should().Be(0);
+
+        scheduler.ExecuteAllPendingActions();
+        sum.Should().Be(2);
+
+        effect.Dispose();
+
+        number2.Value = 3;
+        scheduler.ExecuteAllPendingActions();
+        sum.Should().Be(2);
+    }
+
+    [Fact]
+    void EffectShouldNotRunMultipleTimesInASingleSchedule()
+    {
+        var scheduler = new TestScheduler();
+        var number1 = new Signal<int>();
+        var number2 = new Signal<int>();
+
+        int executionsCount = 0;
+        var effect = new Effect(() =>
+        {
+            _ = number1.Value + number2.Value;
+            executionsCount++;
+        }, scheduler);
+        executionsCount.Should().Be(1);
+        
+        number2.Value = 4;
+        number2.Value = 3;
+        
+        number1.Value = 4;
+        number1.Value = 3;
+        executionsCount.Should().Be(1);
+
+        scheduler.ExecuteAllPendingActions();
+        executionsCount.Should().Be(2);
+
+        effect.Dispose();
+
+        number1.Value = 4;
+        number1.Value = 3;
+        scheduler.ExecuteAllPendingActions();
+        executionsCount.Should().Be(2);
+    }
+
+
+    class TestScheduler : IScheduler
+    {
+        Action? _actions;
+        public void ExecuteAllPendingActions() => _actions?.Invoke();
+        public IDisposable Schedule<TState>(TState state, Func<IScheduler, TState, IDisposable> action)
+        {
+            _actions += () => action(this, state);
+            return Disposable.Empty;
+        }
+
+        public IDisposable Schedule<TState>(TState state, TimeSpan dueTime, Func<IScheduler, TState, IDisposable> action) => Schedule(state, action);
+        public IDisposable Schedule<TState>(TState state, DateTimeOffset dueTime, Func<IScheduler, TState, IDisposable> action) => Schedule(state, action);
+        public DateTimeOffset Now => DateTimeOffset.UnixEpoch;
+    }
+}

--- a/SignalsDotnet/SignalsDotnet.Tests/EffectTests.cs
+++ b/SignalsDotnet/SignalsDotnet.Tests/EffectTests.cs
@@ -90,11 +90,81 @@ public class EffectTests
         executionsCount.Should().Be(2);
     }
 
+    [Fact]
+    void EffectsShouldRunAtTheEndOfAtomicOperations()
+    {
+        var number1 = new Signal<int>();
+        var number2 = new Signal<int>();
+
+        int sum = -1;
+        var effect = new Effect(() => sum = number1.Value + number2.Value);
+        sum.Should().Be(0);
+
+        Effect.AtomicOperation(() =>
+        {
+            number1.Value = 1;
+            sum.Should().Be(0);
+
+            number1.Value = 2;
+            sum.Should().Be(0);
+        });
+        sum.Should().Be(2);
+
+        Effect.AtomicOperation(() =>
+        {
+            number2.Value = 2;
+            sum.Should().Be(2);
+
+            Effect.AtomicOperation(() =>
+            {
+                number2.Value = 3;
+                sum.Should().Be(2);
+            });
+
+            sum.Should().Be(2);
+        });
+
+        sum.Should().Be(5);
+    }
+
+    [Fact]
+    void EffectsShouldRunAtTheEndOfAtomicOperationsWithScheduler()
+    {
+        var scheduler = new TestScheduler();
+        var number1 = new Signal<int>();
+        var number2 = new Signal<int>();
+
+        int sum = -1;
+        var effect = new Effect(() => sum = number1.Value + number2.Value, scheduler);
+        sum.Should().Be(0);
+
+        Effect.AtomicOperation(() =>
+        {
+            number1.Value = 1;
+            scheduler.ExecuteAllPendingActions();
+            sum.Should().Be(0);
+
+            number1.Value = 2;
+            scheduler.ExecuteAllPendingActions();
+            sum.Should().Be(0);
+        });
+        sum.Should().Be(0);
+        
+        scheduler.ExecuteAllPendingActions();
+        sum.Should().Be(2);
+    }
+
 
     class TestScheduler : IScheduler
     {
         Action? _actions;
-        public void ExecuteAllPendingActions() => _actions?.Invoke();
+        public void ExecuteAllPendingActions()
+        {
+            var actions = _actions;
+            _actions = null;
+            actions?.Invoke();
+        }
+
         public IDisposable Schedule<TState>(TState state, Func<IScheduler, TState, IDisposable> action)
         {
             _actions += () => action(this, state);

--- a/SignalsDotnet/SignalsDotnet/Effect.cs
+++ b/SignalsDotnet/SignalsDotnet/Effect.cs
@@ -1,19 +1,60 @@
-﻿using System.Reactive;
+﻿using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Reactive;
 using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading;
+using SignalsDotnet.Internals.Helpers;
 
 namespace SignalsDotnet;
+
+
 public class Effect : IDisposable
 {
+    static readonly ConcurrentDictionary<Thread, BehaviorSubject<int>> _atomicOperationsNestingByThread = new();
     readonly IDisposable _subscription;
+
     public Effect(Action onChange, IScheduler? scheduler = null)
     {
-        scheduler ??= DefaultScheduler;
+        var computationDelayer = ComputationDelayer(scheduler ?? DefaultScheduler);
         _subscription = Signal.ComputedObservable(() =>
-        {
-            onChange();
-            return Unit.Default;
-        }, scheduler).Subscribe();
+                              {
+                                  onChange();
+                                  return Unit.Default;
+                              }, static () => Optional<Unit>.Empty, computationDelayer)
+                              .Subscribe();
     }
+
+    static Func<Unit, IObservable<Unit>> ComputationDelayer(IScheduler? scheduler)
+    {
+        var atomicOperations = _atomicOperationsNestingByThread.GetOrAdd(Thread.CurrentThread, static _ => new BehaviorSubject<int>(0));
+        var noAtomicOperations = atomicOperations.Where(counter => counter == 0)
+                                                 .Select(static _ => Unit.Default);
+
+        return scheduler is null
+            ? _ => noAtomicOperations
+            : _ => noAtomicOperations.ObserveOn(scheduler);
+    }
+
+    public static void AtomicOperation(Action action)
+    {
+        var atomicOperations = _atomicOperationsNestingByThread.AddOrUpdate(Thread.CurrentThread, static _ => new BehaviorSubject<int>(0), (_, subject) =>
+        {
+            subject.OnNext(subject.Value + 1);
+            return subject;
+        });
+
+        try
+        {
+            action();
+        }
+        finally
+        {
+            atomicOperations.OnNext(atomicOperations.Value - 1);
+        }
+    }
+
     public static IScheduler? DefaultScheduler { get; set; }
 
     public void Dispose() => _subscription.Dispose();

--- a/SignalsDotnet/SignalsDotnet/Effect.cs
+++ b/SignalsDotnet/SignalsDotnet/Effect.cs
@@ -1,0 +1,20 @@
+﻿using System.Reactive;
+using System.Reactive.Concurrency;
+
+namespace SignalsDotnet;
+public class Effect : IDisposable
+{
+    readonly IDisposable _subscription;
+    public Effect(Action onChange, IScheduler? scheduler = null)
+    {
+        scheduler ??= DefaultScheduler;
+        _subscription = Signal.ComputedObservable(() =>
+        {
+            onChange();
+            return Unit.Default;
+        }, scheduler).Subscribe();
+    }
+    public static IScheduler? DefaultScheduler { get; set; }
+
+    public void Dispose() => _subscription.Dispose();
+}

--- a/SignalsDotnet/SignalsDotnet/Signal_Computed.cs
+++ b/SignalsDotnet/SignalsDotnet/Signal_Computed.cs
@@ -1,4 +1,7 @@
-﻿using System.Reactive.Disposables;
+﻿using System;
+using System.Reactive;
+using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using SignalsDotnet.Configuration;
 using SignalsDotnet.Internals;
@@ -8,29 +11,6 @@ namespace SignalsDotnet;
 
 public partial class Signal
 {
-    internal static IReadOnlySignal<T> Computed<T>(Func<T> func, Func<Optional<T>> fallbackValue, ReadonlySignalConfigurationDelegate<T?>? configuration)
-    {
-        var valueObservable = Observable.Create<T>(observer =>
-        {
-            var disposable = new SerialDisposable();
-            OnNewResult(ComputeResult(func, fallbackValue));
-            void OnNewResult(ComputationResult<T> result)
-            {
-                disposable.Disposable = result.NextResult
-                                              .Take(1)
-                                              .Subscribe(OnNewResult);
-
-                // We notify a new value only if the func() evaluation succeeds.
-                if (result.ResultOptional.TryGetValue(out var propertyValue))
-                    observer.OnNext(propertyValue);
-            }
-
-            return disposable;
-        });
-
-        return new FromObservableSignal<T>(valueObservable, configuration)!;
-    }
-
     public static IReadOnlySignal<T> Computed<T>(Func<T> func, Func<T> fallbackValue, ReadonlySignalConfigurationDelegate<T?>? configuration = null)
     {
         if (func is null)
@@ -50,8 +30,49 @@ public partial class Signal
         return Computed(func, static () => Optional<T>.Empty, configuration);
     }
 
+    internal static IObservable<T> ComputedObservable<T>(Func<T> func, IScheduler? scheduler = null)
+    {
+        return ComputedObservable(func, static () => Optional<T>.Empty, scheduler);
+    }
 
-    static ComputationResult<T> ComputeResult<T>(Func<T> resultFunc, Func<Optional<T>> fallbackValue)
+    internal static IObservable<T> ComputedObservable<T>(Func<T> func, Func<T> fallbackValue, IScheduler? scheduler = null)
+    {
+        if (func is null)
+            throw new ArgumentNullException(nameof(func));
+
+        return ComputedObservable(func, () => new(fallbackValue()), scheduler);
+    }
+
+    internal static IReadOnlySignal<T> Computed<T>(Func<T> func, Func<Optional<T>> fallbackValue, ReadonlySignalConfigurationDelegate<T?>? configuration)
+    {
+        var valueObservable = ComputedObservable(func, fallbackValue, ImmediateScheduler.Instance);
+
+        return new FromObservableSignal<T>(valueObservable, configuration)!;
+    }
+
+    internal static IObservable<T> ComputedObservable<T>(Func<T> func, Func<Optional<T>> fallbackValue, IScheduler? scheduler = null)
+    {
+        return Observable.Create<T>(observer =>
+        {
+            var disposable = new SerialDisposable();
+            OnNewResult(ComputeResult(func, fallbackValue, scheduler));
+            void OnNewResult(ComputationResult<T> result)
+            {
+                disposable.Disposable = result.NextResult
+                                              .Take(1)
+                                              .Subscribe(OnNewResult);
+
+                // We notify a new value only if the func() evaluation succeeds.
+                if (result.ResultOptional.TryGetValue(out var propertyValue))
+                    observer.OnNext(propertyValue);
+            }
+
+            return disposable;
+        });
+    }
+
+
+    static ComputationResult<T> ComputeResult<T>(Func<T> resultFunc, Func<Optional<T>> fallbackValue, IScheduler? scheduler)
     {
         var referenceEquality = ReferenceEqualityComparer.Instance;
         HashSet<IReadOnlySignal> propertiesRequested = new(referenceEquality);
@@ -70,11 +91,18 @@ public partial class Signal
             }
         }
 
-        var observable = WhenAnyChanged(propertiesRequested)
-                         .Skip(1) // We want to observe only future changes
-                         .Select(_ => ComputeResult(resultFunc, fallbackValue));
 
-        return new(observable, result);
+        var observable = WhenAnyChanged(propertiesRequested).Skip(1); // We want to observe only future changes
+
+        if (scheduler is not null)
+        {
+            observable = observable.Select(x => Observable.Return(x, scheduler))
+                                   .Switch();
+        }
+
+        var restulObsrvable = observable.Select(_ => ComputeResult(resultFunc, fallbackValue, scheduler));
+
+        return new(restulObsrvable, result);
     }
 
     record struct ComputationResult<T>(IObservable<ComputationResult<T>> NextResult, Optional<T> ResultOptional);


### PR DESCRIPTION
I added a class `Effect` that accepts an `Action `and a `IScheduler`:
- The action is immediately executed inside the constructor
- Whenever any signal inside the action change, the effect is scheduled to run again
- If no scheduler (and no default scheduler) is specified, the effect is run immediately when any signal changes
- If multiple signals change before the schedule, the action is executed only once
- There is a static property `Effect.DefaultScheduler` that is used whenever the effect is constructed whitout specifying the scheduler